### PR TITLE
Introduce metric-level tags

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -2,7 +2,7 @@ package metrics
 
 import "sync/atomic"
 
-// Counters hold an int64 value that can be incremented and decremented.
+// Counter holds an int64 value that can be incremented and decremented.
 type Counter interface {
 	Clear()
 	Count() int64

--- a/counter.go
+++ b/counter.go
@@ -9,6 +9,8 @@ type Counter interface {
 	Dec(int64)
 	Inc(int64)
 	Snapshot() Counter
+
+	Taggable
 }
 
 // GetOrRegisterCounter returns an existing Counter or constructs and registers
@@ -25,7 +27,7 @@ func NewCounter() Counter {
 	if UseNilMetrics {
 		return NilCounter{}
 	}
-	return &StandardCounter{0}
+	return &StandardCounter{count: 0}
 }
 
 // NewRegisteredCounter constructs and registers a new StandardCounter.
@@ -39,28 +41,39 @@ func NewRegisteredCounter(name string, r Registry) Counter {
 }
 
 // CounterSnapshot is a read-only copy of another Counter.
-type CounterSnapshot int64
+type CounterSnapshot struct {
+	count int64
+	tags  map[string]string
+}
 
 // Clear panics.
-func (CounterSnapshot) Clear() {
+func (c *CounterSnapshot) Clear() {
 	panic("Clear called on a CounterSnapshot")
 }
 
 // Count returns the count at the time the snapshot was taken.
-func (c CounterSnapshot) Count() int64 { return int64(c) }
+func (c *CounterSnapshot) Count() int64 { return c.count }
 
 // Dec panics.
-func (CounterSnapshot) Dec(int64) {
+func (c *CounterSnapshot) Dec(int64) {
 	panic("Dec called on a CounterSnapshot")
 }
 
 // Inc panics.
-func (CounterSnapshot) Inc(int64) {
+func (c *CounterSnapshot) Inc(int64) {
 	panic("Inc called on a CounterSnapshot")
 }
 
 // Snapshot returns the snapshot.
-func (c CounterSnapshot) Snapshot() Counter { return c }
+func (c *CounterSnapshot) Snapshot() Counter { return c }
+
+// AddTags panics.
+func (c *CounterSnapshot) AddTags(tags map[string]string) {
+	panic("AddTags called on a CounterSnapshot")
+}
+
+// GetTags returns the tags attached to this snapshot.
+func (c *CounterSnapshot) GetTags() map[string]string { return c.tags }
 
 // NilCounter is a no-op Counter.
 type NilCounter struct{}
@@ -80,10 +93,17 @@ func (NilCounter) Inc(i int64) {}
 // Snapshot is a no-op.
 func (NilCounter) Snapshot() Counter { return NilCounter{} }
 
+// AddTags is a no-op.
+func (NilCounter) AddTags(tags map[string]string) {}
+
+// GetTags is a no-op.
+func (NilCounter) GetTags() map[string]string { return nil }
+
 // StandardCounter is the standard implementation of a Counter and uses the
 // sync/atomic package to manage a single int64 value.
 type StandardCounter struct {
 	count int64
+	tags  map[string]string
 }
 
 // Clear sets the counter to zero.
@@ -108,5 +128,28 @@ func (c *StandardCounter) Inc(i int64) {
 
 // Snapshot returns a read-only copy of the counter.
 func (c *StandardCounter) Snapshot() Counter {
-	return CounterSnapshot(c.Count())
+	if len(c.tags) == 0 {
+		return &CounterSnapshot{count: c.Count()}
+	}
+	tagsCopy := map[string]string{}
+	for k, v := range c.tags {
+		tagsCopy[k] = v
+	}
+	return &CounterSnapshot{count: c.Count(), tags: tagsCopy}
+}
+
+// AddTags satisfies the Taggable interface and adds metric-level tags.
+func (c *StandardCounter) AddTags(tags map[string]string) {
+	if c.tags == nil {
+		c.tags = tags
+		return
+	}
+	for k, tag := range tags {
+		c.tags[k] = tag
+	}
+}
+
+// GetTags satisfies the Taggable interface.
+func (c *StandardCounter) GetTags() map[string]string {
+	return c.tags
 }

--- a/registry.go
+++ b/registry.go
@@ -129,10 +129,7 @@ func (r *StandardRegistry) register(name string, i interface{}) error {
 	if _, ok := r.metrics[name]; ok {
 		return DuplicateMetric(name)
 	}
-	switch i.(type) {
-	case Counter, Gauge, GaugeFloat64, Healthcheck, Histogram, Meter, Timer:
-		r.metrics[name] = i
-	}
+	r.metrics[name] = i
 	return nil
 }
 

--- a/taggable.go
+++ b/taggable.go
@@ -1,0 +1,7 @@
+package metrics
+
+// Taggable provides the interface for metrics to have metric-level tags.
+type Taggable interface {
+	AddTags(tags map[string]string)
+	GetTags() map[string]string
+}


### PR DESCRIPTION
This adds metric-level tags via an interface. I only implemented it on the counters for now but would do that for the other metric types as well.

I also targeted this at our master branch because I'm not yet sure about pushing this upstream before it's had time to be used by us.